### PR TITLE
Fixes #10 - Allow providing your own NpgsqlConnectionProvider

### DIFF
--- a/Hangfire.PostgreSql.sln.DotSettings
+++ b/Hangfire.PostgreSql.sln.DotSettings
@@ -2,5 +2,9 @@
 	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=Hangfire_002EAnnotations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=Hangfire_002ERedis_002EAnnotations/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=Hangfire_002ESqlServer_002EAnnotations/@EntryIndexedValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">0</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Constants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/CoverageFilterXml/@EntryValue">&lt;data&gt;&lt;IncludeFilters /&gt;&lt;ExcludeFilters&gt;&lt;Filter ModuleMask="Hangfire.Core.Tests" ModuleVersionMask="*" ClassMask="*" FunctionMask="*" IsEnabled="True" /&gt;&lt;Filter ModuleMask="Hangfire.SqlServer.Tests" ModuleVersionMask="*" ClassMask="*" FunctionMask="*" IsEnabled="True" /&gt;&lt;/ExcludeFilters&gt;&lt;/data&gt;</s:String>
 	<s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String></wpf:ResourceDictionary>

--- a/src/Hangfire.PostgreSql/Connectivity/DefaultConnectionBuilder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/DefaultConnectionBuilder.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Npgsql;
+
+namespace Hangfire.PostgreSql.Connectivity
+{
+    public class DefaultConnectionBuilder : IConnectionBuilder
+    {
+        private readonly Action<NpgsqlConnection> _connectionAction;
+        public NpgsqlConnectionStringBuilder ConnectionStringBuilder { get; }
+
+        public DefaultConnectionBuilder(string connectionString, 
+            Action<NpgsqlConnection> connectionAction = null) 
+            : this(new NpgsqlConnectionStringBuilder(connectionString), connectionAction)
+        {
+            Guard.ThrowIfNull(connectionString, nameof(connectionString));
+            Guard.ThrowIfConnectionStringIsInvalid(connectionString);
+        }
+
+        public DefaultConnectionBuilder(NpgsqlConnectionStringBuilder connectionStringBuilder, 
+            Action<NpgsqlConnection> connectionAction = null)
+        {
+            Guard.ThrowIfNull(connectionStringBuilder, nameof(connectionStringBuilder));
+
+            ConnectionStringBuilder = connectionStringBuilder;
+            _connectionAction = connectionAction;
+        }
+
+        public NpgsqlConnection Build()
+        {
+            var connection = new NpgsqlConnection(ConnectionStringBuilder.ConnectionString);
+
+            // Fixup the connection, if required
+            _connectionAction?.Invoke(connection);
+
+            return connection;
+        }
+    }
+}

--- a/src/Hangfire.PostgreSql/Connectivity/DefaultConnectionBuilder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/DefaultConnectionBuilder.cs
@@ -5,32 +5,54 @@ namespace Hangfire.PostgreSql.Connectivity
 {
     public class DefaultConnectionBuilder : IConnectionBuilder
     {
-        private readonly Action<NpgsqlConnection> _connectionAction;
+        private readonly Action<NpgsqlConnection> _connectionSetup;
+
+        /// <inheritdoc />
         public NpgsqlConnectionStringBuilder ConnectionStringBuilder { get; }
 
+        /// <inheritdoc />
+        /// <summary>
+        /// Create a new connection builder using the supplied connection string and connection
+        /// setup action
+        /// </summary>
+        /// <param name="connectionString">Connection string</param>
+        /// <param name="connectionSetup">Optional setup action to apply to created connections</param>
         public DefaultConnectionBuilder(string connectionString, 
-            Action<NpgsqlConnection> connectionAction = null) 
-            : this(new NpgsqlConnectionStringBuilder(connectionString), connectionAction)
+            Action<NpgsqlConnection> connectionSetup = null) 
+            : this(new NpgsqlConnectionStringBuilder(connectionString), connectionSetup)
         {
             Guard.ThrowIfNull(connectionString, nameof(connectionString));
             Guard.ThrowIfConnectionStringIsInvalid(connectionString);
         }
 
+        /// <summary>
+        /// Create a new connection builder using the supplied connection string builder and
+        /// connection setup action
+        /// </summary>
+        /// <param name="connectionStringBuilder">Connection string builder</param>
+        /// <param name="connectionSetup">Optional setup action to apply to created connections</param>
         public DefaultConnectionBuilder(NpgsqlConnectionStringBuilder connectionStringBuilder, 
-            Action<NpgsqlConnection> connectionAction = null)
+            Action<NpgsqlConnection> connectionSetup = null)
         {
             Guard.ThrowIfNull(connectionStringBuilder, nameof(connectionStringBuilder));
 
             ConnectionStringBuilder = connectionStringBuilder;
-            _connectionAction = connectionAction;
+            _connectionSetup = connectionSetup;
         }
 
+        /// <inheritdoc />
+        /// <summary>
+        /// Create a new connection. If the <see cref="T:Hangfire.PostgreSql.Connectivity.DefaultConnectionBuilder" /> was created
+        /// with a connection setup action, it will be applied to the connection before it is
+        /// returned
+        /// </summary>
+        /// <returns>A new connection, optionally setup using a connection setup action</returns>
         public NpgsqlConnection Build()
         {
             var connection = new NpgsqlConnection(ConnectionStringBuilder.ConnectionString);
 
-            // Fixup the connection, if required
-            _connectionAction?.Invoke(connection);
+            // Setup the connection, if required
+            _connectionSetup?.Invoke(connection);
 
             return connection;
         }

--- a/src/Hangfire.PostgreSql/Connectivity/IConnectionBuilder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/IConnectionBuilder.cs
@@ -2,10 +2,22 @@
 
 namespace Hangfire.PostgreSql.Connectivity
 {
+    /// <summary>
+    /// Builds <see cref="NpgsqlConnection"/> Postgres connections
+    /// </summary>
     public interface IConnectionBuilder
     {
+        /// <summary>
+        /// Used when returning connections in <see cref="Build"/>, this allows you to 'peek'
+        /// at the configuration used by an <see cref="IConnectionBuilder"/>, without actually
+        /// building a connection
+        /// </summary>
         NpgsqlConnectionStringBuilder ConnectionStringBuilder { get; }
 
+        /// <summary>
+        /// Create a new <see cref="NpgsqlConnection"/> Postgres connection
+        /// </summary>
+        /// <returns>A new connection</returns>
         NpgsqlConnection Build();
     }
 }

--- a/src/Hangfire.PostgreSql/Connectivity/IConnectionBuilder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/IConnectionBuilder.cs
@@ -1,0 +1,11 @@
+﻿using Npgsql;
+
+namespace Hangfire.PostgreSql.Connectivity
+{
+    public interface IConnectionBuilder
+    {
+        NpgsqlConnectionStringBuilder ConnectionStringBuilder { get; }
+
+        NpgsqlConnection Build();
+    }
+}

--- a/src/Hangfire.PostgreSql/Connectivity/NpgsqlConnectionProvider.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/NpgsqlConnectionProvider.cs
@@ -1,19 +1,18 @@
-﻿using Npgsql;
-
+﻿
 namespace Hangfire.PostgreSql.Connectivity
 {
     internal sealed class NpgsqlConnectionProvider : IConnectionProvider
     {
-        private readonly string _connectionString;
+        private readonly IConnectionBuilder _connectionBuilder;
 
-        public NpgsqlConnectionProvider(string connectionString)
+        public NpgsqlConnectionProvider(IConnectionBuilder connectionBuilder)
         {
-            _connectionString = connectionString;
+            this._connectionBuilder = connectionBuilder;
         }
 
         public ConnectionHolder AcquireConnection()
         {
-            var connection = new NpgsqlConnection(_connectionString);
+            var connection = _connectionBuilder.Build();
             connection.Open();
             return new ConnectionHolder(connection, holder => holder.Connection.Dispose());
         }

--- a/src/Hangfire.PostgreSql/Connectivity/NpgsqlConnectionProvider.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/NpgsqlConnectionProvider.cs
@@ -7,7 +7,7 @@ namespace Hangfire.PostgreSql.Connectivity
 
         public NpgsqlConnectionProvider(IConnectionBuilder connectionBuilder)
         {
-            this._connectionBuilder = connectionBuilder;
+            _connectionBuilder = connectionBuilder;
         }
 
         public ConnectionHolder AcquireConnection()

--- a/src/Hangfire.PostgreSql/PostgreSqlBootstrapperConfigurationExtensions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlBootstrapperConfigurationExtensions.cs
@@ -1,5 +1,7 @@
-﻿using Hangfire.Annotations;
+﻿using System;
+using Hangfire.Annotations;
 using Hangfire.PostgreSql.Connectivity;
+using Npgsql;
 
 namespace Hangfire.PostgreSql
 {
@@ -33,6 +35,26 @@ namespace Hangfire.PostgreSql
             this GlobalConfiguration configuration,
             IConnectionBuilder connectionBuilder)
         {
+            var storage = new PostgreSqlStorage(connectionBuilder);
+            configuration.UseStorage(storage);
+
+            return storage;
+        }
+
+        /// <summary>
+        /// Tells the bootstrapper to use PostgreSQL as a job storage that can be accessed
+        /// using a connection from the given connection builder.
+        /// </summary>
+        /// <param name="configuration">Configuration</param>
+        /// <param name="connectionStringBuilder">Connection string builder</param>
+        /// <param name="connectionSetup">Optional setup action to apply to connections created using <paramref name="connectionStringBuilder"/></param>
+        [PublicAPI]
+        public static PostgreSqlStorage UsePostgreSqlStorage(
+            this GlobalConfiguration configuration, 
+            NpgsqlConnectionStringBuilder connectionStringBuilder,
+            Action<NpgsqlConnection> connectionSetup = null)
+        {
+            var connectionBuilder = new DefaultConnectionBuilder(connectionStringBuilder);
             var storage = new PostgreSqlStorage(connectionBuilder);
             configuration.UseStorage(storage);
 

--- a/src/Hangfire.PostgreSql/PostgreSqlBootstrapperConfigurationExtensions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlBootstrapperConfigurationExtensions.cs
@@ -1,12 +1,13 @@
 ﻿using Hangfire.Annotations;
+using Hangfire.PostgreSql.Connectivity;
 
 namespace Hangfire.PostgreSql
 {
     public static class PostgreSqlBootstrapperConfigurationExtensions
     {
         /// <summary>
-        /// Tells the bootstrapper to use PostgreSQL as a job storage,
-        /// that can be accessed using the given connection string.
+        /// Tells the bootstrapper to use PostgreSQL as a job storage that can be accessed
+        /// using the given connection string.
         /// </summary>
         /// <param name="configuration">Configuration</param>
         /// <param name="connectionString">Connection string</param>
@@ -22,9 +23,25 @@ namespace Hangfire.PostgreSql
         }
 
         /// <summary>
-        /// Tells the bootstrapper to use PostgreSQL as a job storage
-        /// with the given options, that can be accessed using the specified
-        /// connection string.
+        /// Tells the bootstrapper to use PostgreSQL as a job storage that can be accessed
+        /// using a connection from the given connection builder.
+        /// </summary>
+        /// <param name="configuration">Configuration</param>
+        /// <param name="connectionBuilder">Connection builder</param>
+        [PublicAPI]
+        public static PostgreSqlStorage UsePostgreSqlStorage(
+            this GlobalConfiguration configuration,
+            IConnectionBuilder connectionBuilder)
+        {
+            var storage = new PostgreSqlStorage(connectionBuilder);
+            configuration.UseStorage(storage);
+
+            return storage;
+        }
+
+        /// <summary>
+        /// Tells the bootstrapper to use PostgreSQL as a job storage with the given options,
+        /// that can be accessed using the specified connection string.
         /// </summary>
         /// <param name="configuration">Configuration</param>
         /// <param name="connectionString">Connection string</param>
@@ -42,8 +59,27 @@ namespace Hangfire.PostgreSql
         }
 
         /// <summary>
-        /// Tells the bootstrapper to use PostgreSQL as a job storage,
-        /// that can be accessed using the given connection string.
+        /// Tells the bootstrapper to use PostgreSQL as a job storage with the given options,
+        /// that can be accessed using a connection from the specified connection builder.
+        /// </summary>
+        /// <param name="configuration">Configuration</param>
+        /// <param name="connectionBuilder">Connection builder</param>
+        /// <param name="options">Advanced options</param>
+        [PublicAPI]
+        public static PostgreSqlStorage UsePostgreSqlStorage(
+            this GlobalConfiguration configuration,
+            IConnectionBuilder connectionBuilder,
+            PostgreSqlStorageOptions options)
+        {
+            var storage = new PostgreSqlStorage(connectionBuilder, options);
+            configuration.UseStorage(storage);
+
+            return storage;
+        }
+
+        /// <summary>
+        /// Tells the bootstrapper to use PostgreSQL as a job storage, that can be accessed
+        /// using the given connection string.
         /// </summary>
         /// <param name="configuration">Configuration</param>
         /// <param name="connectionString">Connection string</param>
@@ -59,9 +95,25 @@ namespace Hangfire.PostgreSql
         }
 
         /// <summary>
-        /// Tells the bootstrapper to use PostgreSQL as a job storage
-        /// with the given options, that can be accessed using the specified
-        /// connection string or its name.
+        /// Tells the bootstrapper to use PostgreSQL as a job storage, that can be accessed
+        /// using a connection from the given connection builder.
+        /// </summary>
+        /// <param name="configuration">Configuration</param>
+        /// <param name="connectionBuilder">Connection builder</param>
+        [PublicAPI]
+        public static PostgreSqlStorage UsePostgreSqlStorage(
+            this IGlobalConfiguration configuration,
+            IConnectionBuilder connectionBuilder)
+        {
+            var storage = new PostgreSqlStorage(connectionBuilder);
+            configuration.UseStorage(storage);
+
+            return storage;
+        }
+
+        /// <summary>
+        /// Tells the bootstrapper to use PostgreSQL as a job storage with the given options,
+        /// that can be accessed using the specified connection string or its name.
         /// </summary>
         /// <param name="configuration">Configuration</param>
         /// <param name="connectionString">Connection string</param>
@@ -73,6 +125,25 @@ namespace Hangfire.PostgreSql
             PostgreSqlStorageOptions options)
         {
             var storage = new PostgreSqlStorage(connectionString, options);
+            configuration.UseStorage(storage);
+
+            return storage;
+        }
+
+        /// <summary>
+        /// Tells the bootstrapper to use PostgreSQL as a job storage with the given options,
+        /// that can be accessed using a connection from the specified connection builder.
+        /// </summary>
+        /// <param name="configuration">Configuration</param>
+        /// <param name="connectionBuilder">Connection builder</param>
+        /// <param name="options">Advanced options</param>
+        [PublicAPI]
+        public static PostgreSqlStorage UsePostgreSqlStorage(
+            this IGlobalConfiguration configuration,
+            IConnectionBuilder connectionBuilder,
+            PostgreSqlStorageOptions options)
+        {
+            var storage = new PostgreSqlStorage(connectionBuilder, options);
             configuration.UseStorage(storage);
 
             return storage;

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -39,29 +39,56 @@ namespace Hangfire.PostgreSql
         /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="connectionString"/> is not valid PostgreSql connection string.</exception>
         public PostgreSqlStorage(string connectionString, PostgreSqlStorageOptions options)
+            : this(new DefaultConnectionBuilder(connectionString), options)
         {
-            Guard.ThrowIfNull(connectionString, nameof(connectionString));
+
+        }
+
+        /// <summary>
+        /// Initializes PostgreSqlStorage with the provided connection builder and default PostgreSqlStorageOptions.
+        /// </summary>
+        /// <param name="connectionBuilder">A Postgres connection builder</param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionBuilder"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionBuilder"/> is not valid PostgreSql connection string </exception>
+        public PostgreSqlStorage(IConnectionBuilder connectionBuilder)
+            : this(connectionBuilder, new PostgreSqlStorageOptions())
+        {
+
+        }
+        
+        /// <summary>
+        /// Initializes PostgreSqlStorage with the provided connection builder and the provided PostgreSqlStorageOptions.
+        /// </summary>
+        /// <param name="connectionBuilder">A Postgres connection builder</param>
+        /// <param name="options"></param>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionBuilder"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="connectionBuilder"/> has an invalid PostgreSql connection string.</exception>
+        public PostgreSqlStorage(IConnectionBuilder connectionBuilder, PostgreSqlStorageOptions options)
+        {
+            Guard.ThrowIfNull(connectionBuilder, nameof(connectionBuilder));
             Guard.ThrowIfNull(options, nameof(options));
-            Guard.ThrowIfConnectionStringIsInvalid(connectionString);
+            Guard.ThrowIfConnectionStringIsInvalid(connectionBuilder.ConnectionStringBuilder.ConnectionString);
 
             _options = options;
 
-            var builder = new NpgsqlConnectionStringBuilder(connectionString);
-            _connectionProvider = CreateConnectionProvider(connectionString, builder);
+            _connectionProvider = CreateConnectionProvider(connectionBuilder);
 
             var queue = new JobQueue(_connectionProvider, _options);
             _storageConnection = new StorageConnection(_connectionProvider, queue, _options);
             _monitoringApi = new MonitoringApi(_connectionProvider);
+
+            var builder = connectionBuilder.ConnectionStringBuilder;
             _storageInfo = $"PostgreSQL Server: Host: {builder.Host}, DB: {builder.Database}, Schema: {builder.SearchPath}, Pool: {_connectionProvider.GetType().Name}";
 
             PrepareSchemaIfNecessary(builder.SearchPath);
         }
 
-        private static IConnectionProvider CreateConnectionProvider(string connectionString, NpgsqlConnectionStringBuilder connectionStringBuilder)
+        private static IConnectionProvider CreateConnectionProvider(IConnectionBuilder connectionBuilder)
         {
-            return connectionStringBuilder.Pooling
-                ? new NpgsqlConnectionProvider(connectionString)
-                : (IConnectionProvider)new DefaultConnectionProvider(connectionString);
+            return connectionBuilder.ConnectionStringBuilder.Pooling
+                ? new NpgsqlConnectionProvider(connectionBuilder)
+                : (IConnectionProvider)new DefaultConnectionProvider(connectionBuilder);
         }
 
         private void PrepareSchemaIfNecessary(string schemaName)

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -6,7 +6,6 @@ using Hangfire.PostgreSql.Connectivity;
 using Hangfire.PostgreSql.Maintenance;
 using Hangfire.Server;
 using Hangfire.Storage;
-using Npgsql;
 
 namespace Hangfire.PostgreSql
 {

--- a/tests/Hangfire.PostgreSql.Tests/ConnectionProviderFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/ConnectionProviderFacts.cs
@@ -9,18 +9,12 @@ namespace Hangfire.PostgreSql.Tests
     public class ConnectionProviderFacts
     {
         [Fact]
-        public void Ctor_ThrowsAnException_WhenConnectionStringIsNull()
+        public void Ctor_ThrowsAnException_WhenConnectionBuilderIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
                 () => new DefaultConnectionProvider(null));
-            Assert.Equal("connectionString", exception.ParamName);
-        }
 
-        [Fact]
-        public void Ctor_ThrowsAnException_WhenConnectionStringIsInvalid()
-        {
-            var exception = Assert.Throws<ArgumentException>(
-                () => new DefaultConnectionProvider("testtest"));
+            Assert.Equal("connectionBuilder", exception.ParamName);
         }
 
         [Fact]
@@ -53,7 +47,7 @@ namespace Hangfire.PostgreSql.Tests
         [Fact]
         public void Dispose_ReleasesConnections()
         {
-            var connectionsCount = 10;
+            const int connectionsCount = 10;
             var provider = CreateProvider();
 
             for (var i = 0; i < connectionsCount; i++)
@@ -88,6 +82,6 @@ namespace Hangfire.PostgreSql.Tests
             });
         }
 
-        private static DefaultConnectionProvider CreateProvider() => new DefaultConnectionProvider(ConnectionUtils.GetConnectionString());
+        private static DefaultConnectionProvider CreateProvider() => new DefaultConnectionProvider(ConnectionUtils.GetConnectionBuilder());
     }
 }

--- a/tests/Hangfire.PostgreSql.Tests/DefaultConnectionBuilderFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/DefaultConnectionBuilderFacts.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Hangfire.PostgreSql.Connectivity;
+using Hangfire.PostgreSql.Tests.Utils;
+using Npgsql;
+using Xunit;
+
+namespace Hangfire.PostgreSql.Tests
+{
+    public class DefaultConnectionBuilderFacts
+    {
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenConnectionStringIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new DefaultConnectionBuilder(connectionString: null));
+
+            Assert.Equal("connectionString", exception.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenConnectionStringIsInvalid()
+        {
+            var exception = Assert.Throws<ArgumentException>(
+                () => new DefaultConnectionBuilder("testtest"));
+        }
+
+        [Fact]
+        public void Ctor_ThrowsAnException_WhenConnectionStringBuilderIsNull()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new DefaultConnectionBuilder(connectionStringBuilder: null));
+
+            Assert.Equal("connectionStringBuilder", exception.ParamName);
+        }
+
+        [Fact]
+        public void ConnectionStringBuilder_Is_Readable()
+        {
+            var connectionString = ConnectionUtils.GetConnectionString();
+            var builder = new DefaultConnectionBuilder(connectionString);
+
+            Assert.NotNull(builder.ConnectionStringBuilder);
+            Assert.NotNull(builder.ConnectionStringBuilder.ConnectionString);
+        }
+
+        [Fact]
+        public void Build_CreatesConnection()
+        {
+            var builder = new DefaultConnectionBuilder(ConnectionUtils.GetConnectionString());
+
+            using (var connection = builder.Build())
+            {
+                Assert.NotNull(connection);
+            }
+        }
+
+        [Fact]
+        public void Build_CreatedFixedUpConnection()
+        {
+            void FixUpAction(NpgsqlConnection conn) =>
+                conn.UserCertificateValidationCallback += (sender, cert, chain, errors) => true;
+
+            var builder = new DefaultConnectionBuilder(ConnectionUtils.GetConnectionString(), FixUpAction);
+
+            using (var connection = builder.Build())
+            {
+                Assert.NotNull(connection);
+                Assert.NotNull(connection.UserCertificateValidationCallback);
+            }
+        }
+    }
+}

--- a/tests/Hangfire.PostgreSql.Tests/JobQueueFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/JobQueueFacts.cs
@@ -339,12 +339,12 @@ select i.""id"", @queue from i;
             return new JobQueue(provider, new PostgreSqlStorageOptions());
         }
 
-        private static void UseConnection(Action<NpgsqlConnection> action)
+        private static void UseConnection(Action<NpgsqlConnection> connectionSetup)
         {
             var provider = ConnectionUtils.GetConnectionProvider();
             using (var connection = provider.AcquireConnection())
             {
-                action(connection.Connection);
+                connectionSetup(connection.Connection);
             }
         }
 

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlStorageFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlStorageFacts.cs
@@ -28,7 +28,7 @@ namespace Hangfire.PostgreSql.Tests
         public void Ctor_ThrowsAnException_WhenOptionsValueIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new PostgreSqlStorage("hello", null));
+                () => new PostgreSqlStorage(ConnectionUtils.GetConnectionString(), null));
 
             Assert.Equal("options", exception.ParamName);
         }

--- a/tests/Hangfire.PostgreSql.Tests/Utils/ConnectionUtils.cs
+++ b/tests/Hangfire.PostgreSql.Tests/Utils/ConnectionUtils.cs
@@ -10,7 +10,7 @@ namespace Hangfire.PostgreSql.Tests.Utils
         private const string ConnectionStringVariableName = "Hangfire_PostgreSql_ConnectionString";
 
         private const string DefaultConnectionString =
-            @"Server=docker.cocowalla.ga;Port=5432;Database=hangfire_tests;User Id=postgres;Password=password;Search Path=hangfire";
+            @"Server=localhost;Port=5432;Database=hangfire_tests;User Id=postgres;Password=password;Search Path=hangfire";
 
         public static string GetConnectionString() => Environment.GetEnvironmentVariable(ConnectionStringVariableName) ?? DefaultConnectionString;
         public static IConnectionBuilder GetConnectionBuilder() => new DefaultConnectionBuilder(GetConnectionString());

--- a/tests/Hangfire.PostgreSql.Tests/Utils/ConnectionUtils.cs
+++ b/tests/Hangfire.PostgreSql.Tests/Utils/ConnectionUtils.cs
@@ -10,9 +10,10 @@ namespace Hangfire.PostgreSql.Tests.Utils
         private const string ConnectionStringVariableName = "Hangfire_PostgreSql_ConnectionString";
 
         private const string DefaultConnectionString =
-            @"Server=localhost;Port=5432;Database=hangfire_tests;User Id=postgres;Password=password;Search Path=hangfire";
+            @"Server=docker.cocowalla.ga;Port=5432;Database=hangfire_tests;User Id=postgres;Password=password;Search Path=hangfire";
 
         public static string GetConnectionString() => Environment.GetEnvironmentVariable(ConnectionStringVariableName) ?? DefaultConnectionString;
+        public static IConnectionBuilder GetConnectionBuilder() => new DefaultConnectionBuilder(GetConnectionString());
 
         public static string GetDatabaseName()
         {
@@ -29,15 +30,15 @@ namespace Hangfire.PostgreSql.Tests.Utils
         private static readonly Lazy<IConnectionProvider> LazyConnectionProvider = new Lazy<IConnectionProvider>(() =>
         {
             var connectionString = GetConnectionString();
-            var builder = new NpgsqlConnectionStringBuilder(connectionString);
+            var connectionBuilder = new DefaultConnectionBuilder(connectionString);
 
-            if (builder.Pooling)
+            if (connectionBuilder.ConnectionStringBuilder.Pooling)
             {
-                return new NpgsqlConnectionProvider(connectionString);
+                return new NpgsqlConnectionProvider(connectionBuilder);
             }
             else
             {
-                return new DefaultConnectionProvider(connectionString);
+                return new DefaultConnectionProvider(connectionBuilder);
             }
         }, LazyThreadSafetyMode.ExecutionAndPublication);
 


### PR DESCRIPTION
Allow providing your own NpgsqlConnectionProvider, and fixing up built NpgsqlConnection's (e.g. to attach a client certificate callback, attach a server certificate validator, or to enable .NET's `SslStream` instead of Npgsql's built-in one).