### PR TITLE
WIP: Closes #8: added NpgsqlTransaction support to Hangfire.PostgreSql

### DIFF
--- a/src/Hangfire.PostgreSql/Connectivity/ConnectionHolder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/ConnectionHolder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Data.Common;
+using System.Transactions;
 using Npgsql;
 
 namespace Hangfire.PostgreSql.Connectivity
@@ -43,6 +44,11 @@ namespace Hangfire.PostgreSql.Connectivity
             if (_transaction != null)
             {
                 return new TransactionHolder(_transaction, false, holder => { });
+            }
+
+            if (Transaction.Current != null)
+            {
+                return new TransactionHolder(null, false, holder => { });
             }
 
             var transaction = _connection.BeginTransaction(level);

--- a/src/Hangfire.PostgreSql/Connectivity/ConnectionHolder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/ConnectionHolder.cs
@@ -39,7 +39,7 @@ namespace Hangfire.PostgreSql.Connectivity
             }
         }
 
-        public TransactionHolder BeginTransaction(IsolationLevel level)
+        public TransactionHolder BeginTransaction(System.Data.IsolationLevel level)
         {
             if (_transaction != null)
             {

--- a/src/Hangfire.PostgreSql/Connectivity/ConnectionHolder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/ConnectionHolder.cs
@@ -52,7 +52,7 @@ namespace Hangfire.PostgreSql.Connectivity
             }
 
             var transaction = _connection.BeginTransaction(level);
-            return new TransactionHolder(transaction, true, holder => holder.Transaction.Dispose());
+            return new TransactionHolder(transaction, true, holder => transaction.Dispose());
         }
 
         public bool Disposed { get; private set; }

--- a/src/Hangfire.PostgreSql/Connectivity/DefaultConnectionProvider.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/DefaultConnectionProvider.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics;
 using System.Threading;
-using System.Transactions;
 using Hangfire.Logging;
 using Npgsql;
 

--- a/src/Hangfire.PostgreSql/Connectivity/DefaultConnectionProvider.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/DefaultConnectionProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Data;
 using System.Diagnostics;
 using System.Threading;
+using System.Transactions;
 using Hangfire.Logging;
 using Npgsql;
 

--- a/src/Hangfire.PostgreSql/Connectivity/IConnectionProvider.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/IConnectionProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 
 namespace Hangfire.PostgreSql.Connectivity
 {

--- a/src/Hangfire.PostgreSql/Connectivity/ITransactionHolder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/ITransactionHolder.cs
@@ -1,0 +1,11 @@
+using System;
+using Npgsql;
+
+namespace Hangfire.PostgreSql.Connectivity
+{
+    public interface ITransactionHolder : IDisposable
+    {
+        NpgsqlTransaction Transaction { get; }
+        void Commit();
+    }
+}

--- a/src/Hangfire.PostgreSql/Connectivity/NpgsqlConnectionProvider.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/NpgsqlConnectionProvider.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System.Data;
+
 namespace Hangfire.PostgreSql.Connectivity
 {
     internal sealed class NpgsqlConnectionProvider : IConnectionProvider

--- a/src/Hangfire.PostgreSql/Connectivity/NpgsqlTransactionConnectionProvider.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/NpgsqlTransactionConnectionProvider.cs
@@ -1,0 +1,39 @@
+using System;
+using Dapper;
+using Npgsql;
+
+namespace Hangfire.PostgreSql.Connectivity
+{
+    internal sealed class NpgsqlTransactionConnectionProvider : IConnectionProvider
+    {
+        private readonly NpgsqlTransaction _transaction;
+        private readonly string _hangfireSchemaName;
+        private string _currentSchemaName;
+
+        public NpgsqlTransactionConnectionProvider(NpgsqlTransaction transaction, string hangfireSchema)
+        {
+            _transaction = transaction;
+            _hangfireSchemaName = hangfireSchema;
+        }
+
+        public ConnectionHolder AcquireConnection()
+        {
+            // we actually can't dispose the connection
+            // since the user might still need it
+            _currentSchemaName = _transaction.Connection.QueryFirst<string>("SHOW search_path");
+            _transaction.Connection.Execute($@"SET search_path={_hangfireSchemaName}");
+            var savepoint = "HANGFIRE" + Guid.NewGuid().ToString().Replace("-", "");
+            _transaction.Save(savepoint);
+            return new ConnectionHolder(_transaction.Connection, holder =>
+            {
+                _transaction.Release(savepoint);
+                _transaction.Connection.Execute($@"SET search_path={_currentSchemaName ?? "public"}");
+            }, _transaction);
+        }
+
+        public void Dispose()
+        {
+            // Npgsql will handle disposing of internal pool by itself
+        }
+    }
+}

--- a/src/Hangfire.PostgreSql/Connectivity/TransactionHolder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/TransactionHolder.cs
@@ -1,0 +1,52 @@
+using System;
+using Dapper;
+using Npgsql;
+
+namespace Hangfire.PostgreSql.Connectivity
+{
+    public class TransactionHolder : IDisposable
+    {
+        private readonly NpgsqlTransaction _transaction;
+        private readonly Action<TransactionHolder> _transactionDisposer;
+        private readonly bool _commitable;
+
+        public TransactionHolder(NpgsqlTransaction transaction, bool commitable,
+            Action<TransactionHolder> transactionDisposer)
+        {
+            _transaction = transaction;
+            _transactionDisposer = transactionDisposer;
+            _commitable = commitable;
+        }
+
+        public NpgsqlTransaction Transaction
+        {
+            get
+            {
+                if (Disposed)
+                {
+                    throw new ObjectDisposedException(nameof(TransactionHolder));
+                }
+
+                return _transaction;
+            }
+        }
+
+        public void Commit()
+        {
+            if (_commitable)
+            {
+                _transaction.Commit();
+            }
+        }
+
+        public bool Disposed { get; private set; }
+
+        public void Dispose()
+        {
+            if (Disposed) return;
+
+            _transactionDisposer(this);
+            Disposed = true;
+        }
+    }
+}

--- a/src/Hangfire.PostgreSql/Connectivity/TransactionHolder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/TransactionHolder.cs
@@ -6,7 +6,6 @@ namespace Hangfire.PostgreSql.Connectivity
 {
     public class TransactionHolder : ITransactionHolder
     {
-        private readonly NpgsqlConnection _connection;
         private readonly NpgsqlTransaction _transaction;
         private readonly Action<TransactionHolder> _transactionDisposer;
         private readonly bool _commitable;
@@ -17,7 +16,6 @@ namespace Hangfire.PostgreSql.Connectivity
         {
             _transaction = transaction;
             _transactionDisposer = transactionDisposer;
-            _connection = connection;
             _commitable = commitable;
         }
 

--- a/src/Hangfire.PostgreSql/Connectivity/TransactionHolder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/TransactionHolder.cs
@@ -6,15 +6,18 @@ namespace Hangfire.PostgreSql.Connectivity
 {
     public class TransactionHolder : ITransactionHolder
     {
+        private readonly NpgsqlConnection _connection;
         private readonly NpgsqlTransaction _transaction;
         private readonly Action<TransactionHolder> _transactionDisposer;
         private readonly bool _commitable;
 
-        public TransactionHolder(NpgsqlTransaction transaction, bool commitable,
+        public TransactionHolder(NpgsqlTransaction transaction,
+            bool commitable,
             Action<TransactionHolder> transactionDisposer)
         {
             _transaction = transaction;
             _transactionDisposer = transactionDisposer;
+            _connection = connection;
             _commitable = commitable;
         }
 

--- a/src/Hangfire.PostgreSql/Connectivity/TransactionHolder.cs
+++ b/src/Hangfire.PostgreSql/Connectivity/TransactionHolder.cs
@@ -4,7 +4,7 @@ using Npgsql;
 
 namespace Hangfire.PostgreSql.Connectivity
 {
-    public class TransactionHolder : IDisposable
+    public class TransactionHolder : ITransactionHolder
     {
         private readonly NpgsqlTransaction _transaction;
         private readonly Action<TransactionHolder> _transactionDisposer;

--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -4,7 +4,7 @@
     <Copyright>Copyright © 2014-2017 Frank Hommers, Burhan Irmikci (barhun), Zachary Sims(zsims), kgamecarter, Stafford Williams (staff0rd), briangweber, Viktor Svyatokha (ahydrax), Christopher Dresel (Dresel), Ben Herila (bherila), Vytautas Kasparavičius (vytautask)</Copyright>
     <AssemblyTitle>Hangfire PostgreSql Storage</AssemblyTitle>
     <Authors>Frank Hommers, Burhan Irmikci (barhun), Zachary Sims(zsims), kgamecarter, Stafford Williams (staff0rd), briangweber, Viktor Svyatokha (ahydrax), Christopher Dresel (Dresel), Ben Herila (bherila), Vytautas Kasparavičius (vytautask)</Authors>
-    <TargetFrameworks>netstandard1.6;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <AssemblyName>Hangfire.PostgreSql</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>Hangfire.PostgreSql.ahydrax</PackageId>

--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -19,9 +19,6 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Company>Frank Hommers, Burhan Irmikci (barhun), Zachary Sims(zsims), kgamecarter, Stafford Williams (staff0rd), briangweber, Viktor Svyatokha (ahydrax), Christopher Dresel (Dresel), Ben Herila (bherila), Vytautas Kasparavičius (vytautask)</Company>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <DefineConstants>$(DefineConstants);NETCORE1</DefineConstants>
-  </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System" />

--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -44,6 +44,9 @@
     <EmbeddedResource Include="Schema\Install.v7.sql" />
     <EmbeddedResource Include="Schema\Install.v8.sql" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Hangfire.Core" Version="1.6.20" />

--- a/src/Hangfire.PostgreSql/Maintenance/CountersAggregationManager.cs
+++ b/src/Hangfire.PostgreSql/Maintenance/CountersAggregationManager.cs
@@ -63,7 +63,7 @@ namespace Hangfire.PostgreSql.Maintenance
         private void AggregateCounter(string counterName)
         {
             using (var connectionHolder = _connectionProvider.AcquireConnection())
-            using (var transaction = connectionHolder.Connection.BeginTransaction(IsolationLevel.ReadCommitted))
+            using (var transactionHolder = connectionHolder.BeginTransaction(IsolationLevel.ReadCommitted))
             {
                 const string aggregateQuery = @"
 WITH counters AS (
@@ -76,8 +76,8 @@ RETURNING *
 SELECT SUM(value) FROM counters;
 ";
 
-                var aggregatedValue = connectionHolder.Connection.ExecuteScalar<long>(aggregateQuery, new { counterName }, transaction);
-                transaction.Commit();
+                var aggregatedValue = connectionHolder.Connection.ExecuteScalar<long>(aggregateQuery, new { counterName }, transactionHolder.Transaction);
+                transactionHolder.Commit();
 
                 if (aggregatedValue > 0)
                 {

--- a/src/Hangfire.PostgreSql/StorageConnection.cs
+++ b/src/Hangfire.PostgreSql/StorageConnection.cs
@@ -54,7 +54,7 @@ namespace Hangfire.PostgreSql
 
             const string createJobSql = @"
 INSERT INTO job (invocationdata, arguments, createdat, expireat)
-VALUES (@invocationData, @arguments, @createdAt, @expireAt) 
+VALUES (@invocationData, @arguments, @createdAt, @expireAt)
 RETURNING id;
 ";
             var invocationData = InvocationData.Serialize(job);
@@ -105,8 +105,8 @@ VALUES (@jobId, @name, @value);
             Guard.ThrowIfNull(jobId, nameof(jobId));
 
             const string sql = @"
-SELECT ""invocationdata"" ""invocationData"", ""statename"" ""stateName"", ""arguments"", ""createdat"" ""createdAt"" 
-FROM job 
+SELECT ""invocationdata"" ""invocationData"", ""statename"" ""stateName"", ""arguments"", ""createdat"" ""createdAt""
+FROM job
 WHERE ""id"" = @id;
 ";
 
@@ -230,10 +230,10 @@ DO UPDATE SET ""value"" = @value
             using (var connectionHolder = _connectionProvider.AcquireConnection())
             {
                 const string query = @"
-SELECT ""value"" 
-FROM ""set"" 
-WHERE ""key"" = @key 
-AND ""score"" BETWEEN @from AND @to 
+SELECT ""value""
+FROM ""set""
+WHERE ""key"" = @key
+AND ""score"" BETWEEN @from AND @to
 ORDER BY ""score"" LIMIT 1;
 ";
                 return connectionHolder.Connection.Query<string>(query, new { key, from = fromScore, to = toScore })
@@ -268,20 +268,21 @@ DO UPDATE SET value = @value
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
 
+
             using (var connectionHolder = _connectionProvider.AcquireConnection())
-            using (var transaction = connectionHolder.Connection.BeginTransaction(IsolationLevel.ReadCommitted))
+            using (var transactionHolder = connectionHolder.BeginTransaction(IsolationLevel.ReadCommitted))
             {
                 const string query = @"
-SELECT field AS Field, value AS Value 
-FROM hash 
+SELECT field AS Field, value AS Value
+FROM hash
 WHERE key = @key
 ;";
-                var result = transaction.Connection.Query<SqlHash>(
+                var result = transactionHolder.Transaction.Connection.Query<SqlHash>(
                         query,
                         new { key = key },
-                        transaction)
+                        transactionHolder.Transaction)
                     .ToDictionary(x => x.Field, x => x.Value);
-                transaction.Commit();
+                transactionHolder.Commit();
 
                 return result.Count != 0 ? result : null;
             }
@@ -328,8 +329,8 @@ DO UPDATE SET data = @data, lastheartbeat = NOW() AT TIME ZONE 'UTC'
             Guard.ThrowIfNull(serverId, nameof(serverId));
 
             const string query = @"
-UPDATE server 
-SET lastheartbeat = NOW() AT TIME ZONE 'UTC' 
+UPDATE server
+SET lastheartbeat = NOW() AT TIME ZONE 'UTC'
 WHERE id = @id;";
 
             using (var connectionHolder = _connectionProvider.AcquireConnection())
@@ -417,7 +418,7 @@ WHERE id = @id;";
 
             const string query = @"
 select ""value"" from (
-    select ""value"", row_number() over (order by ""id"" desc) as row_num 
+    select ""value"", row_number() over (order by ""id"" desc) as row_num
     from ""list""
     where ""key"" = @key ) as s
 where s.row_num between @startingFrom and @endingAt";
@@ -463,9 +464,9 @@ where s.row_num between @startingFrom and @endingAt";
 
             const string query = @"
 select ""value"" from (
-    select ""value"", row_number() over (order by ""id"" ASC) as row_num 
+    select ""value"", row_number() over (order by ""id"" ASC) as row_num
     from ""set""
-    where ""key"" = @key 
+    where ""key"" = @key
     ) as s
 where s.row_num between @startingFrom and @endingAt";
 

--- a/src/Hangfire.PostgreSql/StorageConnection.cs
+++ b/src/Hangfire.PostgreSql/StorageConnection.cs
@@ -277,7 +277,7 @@ SELECT field AS Field, value AS Value
 FROM hash
 WHERE key = @key
 ;";
-                var result = transactionHolder.Transaction.Connection.Query<SqlHash>(
+                var result = connectionHolder.Connection.Query<SqlHash>(
                         query,
                         new { key = key },
                         transactionHolder.Transaction)


### PR DESCRIPTION
@ahydrax: this is a PR that would solve Issue #8, it still needs tests, however I already tested it and it looks working.

The design is as follow:

```
 using (var transaction = await _applicationContext.Database.BeginTransactionAsync(IsolationLevel.RepeatableRead))
            {
                // other sql commands

                var storage = new PostgreSqlStorage(npgsql, "hangfire");
                var client = new RecurringJobManager(storage);
                
                client.AddOrUpdate($"my-job", JobFromBackup(backupJob), cron);

                transaction.Commit();
            }
```

it will only work with a `NpgsqlTransaction` since `TransactionScope` is only supported within .net standard >= 2.0